### PR TITLE
Update resources and blog content, remove TikTok promotion

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -94,18 +94,6 @@ const categoryColors: Record<string, string> = {
       <p class="intro">Map who you are, before deciding who you become.</p>
     </div>
 
-    <div class="blog-intro">
-      <p>Most personal development starts with the wrong question. Books, courses, and coaches jump straight to who you should become, what habits to build, what goals to chase. Nobody stops to ask where you actually are right now.</p>
-      <p>That's the gap Modern Compass was built to fill.</p>
-      <p>Modern Compass is a self-assessment framework built around four directions: Self, Trust, Character, and Relationships. Each direction has four progressive layers that build on each other, giving you a honest picture of where you are across the full spectrum of who you are, not just one slice of it. The subtitle says it plainly: map who you are before deciding who you become.</p>
-      <p>Here's what each direction covers.</p>
-      <p>Self is your foundation. It moves from basic self-awareness through self-worth and confidence, up to self-control. Most people skip straight to confidence-building without doing the worth work first, which is why the confidence doesn't stick.</p>
-      <p>Trust starts with understanding the core tenets of establishing trust. It builds toward trust in other people, informed judgment about who deserves that trust, and eventually a kind of profound trust that only comes from experience and consistency.</p>
-      <p>Character is the direction most personal development gets wrong. It's not a fixed trait you either have or don't. Character is the product you display to the world through your actions, effort, and integrity. It progresses from patterns shaped by your environment, through deliberate development, to authentic expression, and finally toward something driven by serve outside of yourself.</p>
-      <p>Relationships covers how you actually connect with people, starting with empathy and building through resonance, affinity, and genuine loyalty. Understanding where you are in this direction explains a lot about why some relationships feel effortless and others keep hitting the same wall.</p>
-      <p>The articles below explore these directions and layers through real situations, honest examples, and practical frameworks. Whether you're feeling stuck, navigating a transition, or just trying to understand yourself better, start wherever feels most relevant.</p>
-    </div>
-
     {posts.length === 0 ? (
       <div class="no-posts">
         <p>No blog posts yet. Check back soon for insights on personal growth and finding direction.</p>
@@ -125,6 +113,18 @@ const categoryColors: Record<string, string> = {
             <img src="/categories/latest.svg" alt="Latest Posts" class="nav-icon" loading="lazy" />
             <span class="nav-label">Latest Posts</span>
           </a>
+        </div>
+
+        <div class="blog-intro">
+          <p>Most personal development starts with the wrong question. Books, courses, and coaches jump straight to who you should become, what habits to build, what goals to chase. Nobody stops to ask where you actually are right now.</p>
+          <p>That's the gap Modern Compass was built to fill.</p>
+          <p>Modern Compass is a self-assessment framework built around four directions: Self, Trust, Character, and Relationships. Each direction has four progressive layers that build on each other, giving you a honest picture of where you are across the full spectrum of who you are, not just one slice of it. The subtitle says it plainly: map who you are before deciding who you become.</p>
+          <p>Here's what each direction covers.</p>
+          <p>Self is your foundation. It moves from basic self-awareness through self-worth and confidence, up to self-control. Most people skip straight to confidence-building without doing the worth work first, which is why the confidence doesn't stick.</p>
+          <p>Trust starts with understanding the core tenets of establishing trust. It builds toward trust in other people, informed judgment about who deserves that trust, and eventually a kind of profound trust that only comes from experience and consistency.</p>
+          <p>Character is the direction most personal development gets wrong. It's not a fixed trait you either have or don't. Character is the product you display to the world through your actions, effort, and integrity. It progresses from patterns shaped by your environment, through deliberate development, to authentic expression, and finally toward something driven by serve outside of yourself.</p>
+          <p>Relationships covers how you actually connect with people, starting with empathy and building through resonance, affinity, and genuine loyalty. Understanding where you are in this direction explains a lot about why some relationships feel effortless and others keep hitting the same wall.</p>
+          <p>The articles below explore these directions and layers through real situations, honest examples, and practical frameworks. Whether you're feeling stuck, navigating a transition, or just trying to understand yourself better, start wherever feels most relevant.</p>
         </div>
 
         <!-- Category Sections -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -135,7 +135,7 @@ import SEO from '../components/SEO.astro';
         I am writing this for others who feel that way, whether you're just starting out, navigating a midlife pivot, or looking for clarity in any major transition.
         While this book is not about parenthood, I am also writing what I would want
         my daughters to have as they navigate life.
-        As I close most of my newsletters and TikTok posts, always… follow your compass.
+        As I close most of my newsletters and social posts, always… follow your compass.
       </p>
     </div>
   </section>

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -112,13 +112,14 @@ const bookshelf = [
   { title: 'Atomic Habits', author: 'James Clear', href: 'https://jamesclear.com/atomic-habits', note: '' },
   { title: '7 Habits of Highly Effective People', author: 'Stephen Covey', href: 'https://www.franklincovey.com/courses/the-7-habits/', note: '' },
   { title: 'The Defining Decade', author: 'Meg Jay', href: 'https://www.megjay.com/the-defining-decade', note: '' },
+  { title: 'Unhinged Habits', author: 'Jonathan Goodman', href: 'https://www.amazon.com/s?k=Unhinged+Habits+Jonathan+Goodman', note: '' },
 ]
 
 const apps = [
   {
-    name: 'ChatGPT Plus',
-    href: 'https://chat.openai.com/',
-    note: 'My everyday copilot for brainstorming, research, formatting, and scaffolding code.',
+    name: 'Claude Pro',
+    href: 'https://claude.ai/',
+    note: 'The best LLM available. Superior memory across conversations and built to challenge your thinking rather than just tell you what you want to hear.',
   },
   {
     name: 'Atoms by James Clear',
@@ -126,21 +127,17 @@ const apps = [
     note: 'A habit tracker that builds on the Atomic Habits framework to make small actions stick.',
   },
   {
-    name: 'Impulse Wallet (Coming)',
-    href: '/tools/impulse-wallet',
-    note: 'A Modern Compass web app to track your impulses and compare weekly scores with friends or family.',
+    name: 'Impulse Wallet',
+    href: '/apps',
+    note: 'A Modern Compass app to track your impulses and compare weekly scores with friends or family. Free for newsletter subscribers.',
   },
 ]
 
 const newsletters = [
   { name: 'James Clear 3-2-1', href: 'https://jamesclear.com/3-2-1', note: 'Short weekly prompts that pair well with micro actions.' },
   { name: 'Deep Culture', href: 'https://deepculture.substack.com', note: 'Interesting finds across the internet.' },
+  { name: 'The One Thing Better', href: 'https://www.jasonfeifer.com/newsletter/', note: 'Jason Feifer on making one thing better every week.' },
 ]
-
-const tiktok = {
-  href: 'https://www.tiktok.com/@themoderncompass',
-  blurb: 'Follow for videos on confidence, trust, practical relationship skills, and more that bring the book to life.',
-}
 
 const newsletterCTA = {
 heading: 'Clearer direction in your inbox',
@@ -238,14 +235,6 @@ body: 'One practical insight and hand-picked tools to help you take the next ste
           </li>
         ))}
       </ul>
-    </div>
-
-    <div class="promo">
-      <div class="promo-copy">
-        <h3>TikTok</h3>
-        <p>{tiktok.blurb}</p>
-      </div>
-      <a href={tiktok.href} class="button ghost" rel="nofollow noopener" target="_blank">Visit @themoderncompass</a>
     </div>
 
     <div class="cta">


### PR DESCRIPTION
## Summary
This PR updates the resources page and blog index with content changes, removes TikTok promotion, and reorganizes the blog introduction section.

## Key Changes

**Resources Page (`src/pages/resources.astro`)**
- Added "Unhinged Habits" by Jonathan Goodman to the bookshelf
- Replaced ChatGPT Plus with Claude Pro as the primary LLM recommendation with updated description emphasizing superior memory and critical thinking
- Updated Impulse Wallet entry: removed "(Coming)" status, changed link from `/tools/impulse-wallet` to `/apps`, and updated description to mention free access for newsletter subscribers
- Added "The One Thing Better" newsletter by Jason Feifer to the newsletters list
- Removed the entire TikTok promotion section and associated data object

**Blog Index (`src/pages/blog/index.astro`)**
- Moved the blog introduction section from appearing before the post list to appearing after the first post, improving content flow and progressive disclosure of information

**Home Page (`src/pages/index.astro`)**
- Updated closing message from "TikTok posts" to "social posts" for more general language

## Implementation Details
- All changes are data-driven updates to content arrays and text
- No structural or component changes were made
- The TikTok removal is part of a broader shift away from that platform
- Blog introduction repositioning maintains all content while improving UX by showing posts first

https://claude.ai/code/session_01S12iPVMwguYudrp1D6H1b3