### PR TITLE
Remove Shop link from navigation menus

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -121,7 +121,6 @@ src="https://www.facebook.com/tr?id=705209105898090&ev=PageView&noscript=1"
     <li><a href="/newsletter/">Newsletter</a></li>
     <li><a href="/blog/">Blog</a></li>
     <li><a href="/apps/">Apps</a></li>
-    <li><a href="/shop/">Shop</a></li>
     <li><a href="/resources/">Resources</a></li>
   </ul>
   <ul class="nav-links right">
@@ -148,7 +147,6 @@ src="https://www.facebook.com/tr?id=705209105898090&ev=PageView&noscript=1"
         <li><a href="/newsletter/">Newsletter</a></li>
         <li><a href="/blog/">Blog</a></li>
         <li><a href="/apps/">Apps</a></li>
-        <li><a href="/shop/">Shop</a></li>
         <li><a href="/resources/">Resources</a></li>
         <li><a href="/about/">About</a></li>
       </ul>


### PR DESCRIPTION
## Summary
This PR removes the Shop navigation link from both the primary and mobile navigation menus in the Layout component.

## Changes
- Removed Shop link (`/shop/`) from the main navigation menu
- Removed Shop link (`/shop/`) from the mobile navigation menu

## Details
The Shop link has been removed from two locations in `src/layouts/Layout.astro`:
1. The primary horizontal navigation list (line 124)
2. The mobile/responsive navigation menu (line 151)

The remaining navigation structure includes Newsletter, Blog, Apps, Resources, and About links as appropriate for each menu.

https://claude.ai/code/session_015epTxDjnGgf47Qa7Wng3Ey