### PR TITLE
Add trailing slash debug report documenting root cause and fix

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,5 +6,8 @@ import sitemap from '@astrojs/sitemap';
 export default defineConfig({
   site: 'https://themoderncompass.io',
   trailingSlash: 'never',
+  build: {
+    format: 'file',
+  },
   integrations: [sitemap()],
 });

--- a/trailing-slash-debug-report.md
+++ b/trailing-slash-debug-report.md
@@ -1,0 +1,53 @@
+# Trailing Slash Redirect Debug Report
+
+## What's NOT the cause
+
+- **No `_redirects` file** anywhere — not in `public/`, `dist/`, or the project root.
+- **No `vercel.json`, `netlify.toml`, `_headers`** or any other hosting config files.
+- **No Cloudflare Worker setup** — no `wrangler.toml`, no `functions/` directory. This is pure static Pages output.
+- **No middleware** — no `middleware.ts/js` anywhere.
+- **The SEO component** (`src/components/SEO.astro:44-47`) actually does the opposite — it *strips* trailing slashes from canonical URLs. That's correct behavior, not a cause.
+
+---
+
+## Root Cause: `trailingSlash: 'never'` doesn't affect static build output
+
+**File:** `astro.config.mjs`, line 8
+
+```js
+trailingSlash: 'never',
+```
+
+This setting is misleading. Per Astro's documentation, **`trailingSlash` only controls the dev server and SSR routing behavior — it does NOT change the static build output format.**
+
+With the current config and no `build.format` set, Astro uses the default `build.format: 'directory'`, which produces this file structure:
+
+```
+dist/
+  about/index.html      ← Cloudflare sees this → redirects /about → /about/
+  blog/index.html       ← Cloudflare sees this → redirects /blog  → /blog/
+  book/index.html       ← Cloudflare sees this → redirects /book  → /book/
+  blog/
+    my-post/index.html  ← Cloudflare sees this → redirects /blog/my-post → /blog/my-post/
+```
+
+**Cloudflare Pages' static file server has its own built-in logic: when it finds `about/index.html`, it redirects bare `/about` → `/about/` with a 301.** The `trailingSlash: 'never'` setting never reaches Cloudflare — Cloudflare's own layer intercepts first.
+
+---
+
+## The Fix
+
+Add `build.format: 'file'` to `astro.config.mjs`:
+
+```js
+export default defineConfig({
+  site: 'https://themoderncompass.io',
+  trailingSlash: 'never',
+  build: {
+    format: 'file',   // generates about.html instead of about/index.html
+  },
+  integrations: [sitemap()],
+});
+```
+
+This makes Astro output flat files (`about.html`, `blog.html`, `book.html`, `blog/my-post.html`), so Cloudflare Pages has no directory-based `index.html` to trigger a trailing slash redirect.


### PR DESCRIPTION
Documents why trailingSlash: 'never' in astro.config.mjs doesn't
prevent Cloudflare Pages from adding trailing slash redirects, and
the build.format: 'file' fix needed to resolve it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SzYM5HJrjjc4tnxc4iwCwp